### PR TITLE
Remove version locking on poetry_core to fix regex error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ black = "^22.10.0"
 isort = {extras = ["requirements_deprecated_finder"], version = "^5.10.1"}
 
 [tool.poetry.extras]
-requires = ["poetry_core>=1.0.0"]
+requires = ["poetry_core"]
 build-backend = ["poetry.core.masonry.api"]
 testing = ["django-redis", "croniter", "hiredis", "psutil", "iron-mq", "boto3", "pymongo", "blessed", "redis", "setproctitle"]
 rollbar = ["django-q-rollbar"]


### PR DESCRIPTION
Update needed to `pyproject.toml` to work with latest poetry version. 

Error: 
```
The Poetry configuration is invalid:
   - [extras.requires.0] 'poetry_core>=1.0.0' does not match '^[a-zA-Z-_.0-9]+$'
```