### PR TITLE
Rerun successful tasks

### DIFF
--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -32,6 +32,7 @@ class TaskAdmin(admin.ModelAdmin):
     """model admin for success tasks."""
 
     list_display = ("name", "group", "func", "cluster", "started", "stopped", "time_taken")
+    actions = [resubmit_task]
 
     def has_add_permission(self, request):
         """Don't allow adds."""

--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -60,7 +60,7 @@ class FailAdmin(admin.ModelAdmin):
         """Don't allow adds."""
         return False
 
-    actions = [retry_failed]
+    actions = [resubmit_task]
     search_fields = ("name", "func", "group")
     list_filter = ("group", "cluster")
     readonly_fields = []

--- a/django_q/tests/test_admin.py
+++ b/django_q/tests/test_admin.py
@@ -84,3 +84,10 @@ def test_admin_views(admin_client, monkeypatch):
     data = {"post": "yes"}
     response = admin_client.post(url, data)
     assert response.status_code == 302
+    # Resubmit a successful task.
+    url = reverse("admin:django_q_success_changelist")
+    data = {"action": "resubmit_task", "_selected_action": [t.pk]}
+    initial_queue_count = OrmQ.objects.count()
+    response = admin_client.post(url, data)
+    assert response.status_code == 302
+    assert OrmQ.objects.count() > initial_queue_count

--- a/django_q/tests/test_admin.py
+++ b/django_q/tests/test_admin.py
@@ -64,7 +64,7 @@ def test_admin_views(admin_client, monkeypatch):
 
     # resubmit the failure
     url = reverse("admin:django_q_failure_changelist")
-    data = {"action": "retry_failed", "_selected_action": [f.pk]}
+    data = {"action": "resubmit_task", "_selected_action": [f.pk]}
     response = admin_client.post(url, data)
     assert response.status_code == 302
     assert Failure.objects.filter(name=f.id).exists() is False


### PR DESCRIPTION
It is often useful to be able to easily re-run a successful task via the admin interface.

Along with this feature implementation, to keep the code DRY I have updated the retry failed admin class to use the same `resubmit_task` function since they are nearly identical except for the fact that when we retry a failed task, we want to delete the original failure.