### PR TITLE
Remove deprecated usage pkg_resources

### DIFF
--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -1,15 +1,21 @@
 import logging
 import os
+import sys
 from copy import deepcopy
 from multiprocessing import cpu_count
 from signal import signal
 from warnings import warn
 
-import pkg_resources
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from django_q.queues import Queue
+
+# The "selectable" entry points were introduced in importlib_metadata 3.6 and Python 3.10.
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 # optional
 try:
@@ -276,9 +282,7 @@ if Conf.ERROR_REPORTER:
         # iterate through the configured error reporters,
         # and instantiate an ErrorReporter using the provided config
         for name, conf in error_conf.items():
-            for entry in pkg_resources.iter_entry_points(
-                "djangoq.errorreporters", name
-            ):
+            for entry in entry_points(group="djangoq.errorreporters", name=name):
                 Reporter = entry.load()
                 reporters.append(Reporter(**conf))
         error_reporter = ErrorReporter(reporters)

--- a/poetry.lock
+++ b/poetry.lock
@@ -685,14 +685,14 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.1.0"
+version = "6.8.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-6.1.0-py3-none-any.whl", hash = "sha256:ff80f3b5394912eb1b108fcfd444dc78b7f1f3e16b16188054bd01cb9cb86f09"},
-    {file = "importlib_metadata-6.1.0.tar.gz", hash = "sha256:43ce9281e097583d758c2c708c4376371261a02c34682491a8e98352365aad20"},
+    {file = "importlib_metadata-6.8.0-py3-none-any.whl", hash = "sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb"},
+    {file = "importlib_metadata-6.8.0.tar.gz", hash = "sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"},
 ]
 
 [package.dependencies]
@@ -701,7 +701,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
 name = "iniconfig"
@@ -1660,7 +1660,7 @@ requests = "*"
 name = "zipp"
 version = "3.15.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1682,4 +1682,4 @@ testing = ["blessed", "boto3", "croniter", "django-redis", "hiredis", "iron-mq",
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <4"
-content-hash = "3cfb2c090b4b31cd5f3603b9cab6e26c79eeb4c1bda388fe7927438129100dd4"
+content-hash = "e0fa03b0ce373b27878cd5108433d704c91f728e2b410605fcaa1ad82c10dabf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ django-q-rollbar = {version = ">=0.1", optional = true}
 django-q-sentry = {version = ">=0.1", optional = true}
 redis = {version = "^4.3.4", optional = true}
 setproctitle = {version = "^1.3.2", optional = true}
+importlib-metadata = {version = ">=3.6", python = "<3.10"}
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
List entry points using `importlib.metadata` (Python >=3.10) or `importlib-metadata>=3.6` (Python < 3.10).
See compatibility notes in https://docs.python.org/3/library/importlib.metadata.html#entry-points.