### PR TITLE
DOCS: Correct health check import in examples.rst

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -328,7 +328,7 @@ Requires cache to be enabled. Save file in your Django project's root directory 
     # All django stuff has to come after the setup:
     django.setup()
 
-    from django_q.monitor import Stat
+    from django_q.status import Stat
     from django_q.conf import Conf
 
     # Set host and port settings

--- a/docs/monitor.rst
+++ b/docs/monitor.rst
@@ -111,7 +111,7 @@ You can check the status of your clusters straight from your code with the :clas
 
 .. code:: python
 
-    from django_q.monitor import Stat
+    from django_q.status import Stat
 
     for stat in Stat.get_all():
         print(stat.cluster_id, stat.status)


### PR DESCRIPTION
The health check example in the docs had a bad import for `Stat`. It worked while the `monitor` file was importing `Stat`, but as of 1.5.5 this no longer works.