### PR TITLE
Fix German Translation Typo

### DIFF
--- a/django_q/locale/de/LC_MESSAGES/django.po
+++ b/django_q/locale/de/LC_MESSAGES/django.po
@@ -318,7 +318,7 @@ msgstr "Anzahl Minuten für den Typ 'Minuten'"
 
 #: models.py:205
 msgid "Repeats"
-msgstr "Wiederhohlungen"
+msgstr "Wiederholungen"
 
 #: models.py:205
 msgid "n = n times, -1 = forever"


### PR DESCRIPTION
Fixing a typo in the german translation .po file.