### PR TITLE
Specify build system in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [tool.poetry]
 name = "django-q2"
 version = "1.6.1"


### PR DESCRIPTION
Otherwise, trying to build the project with a tool like gpep517 or build results in using the setuptools legacy backend instead