### PR TITLE
Fix for Negative Repeat Count in Scheduler (#101)

### DIFF
--- a/django_q/scheduler.py
+++ b/django_q/scheduler.py
@@ -82,7 +82,15 @@ def scheduler(broker: Broker = None):
                             break
 
                     s.next_run = next_run
-                    # s.repeats += -1 # Do not count the runs here, maybe use another variable for it
+
+                    # Little Fix for already broken numbers
+                    if s.repeats < -1:
+                        s.repeats = -1
+                    
+                    # Check if the value is not zero
+                    if s.repeats > 0:
+                        s.repeats -= 1
+
                 # send it to the cluster; any cluster name is allowed in multi-queue scenarios
                 # because `broker_name` is confusing, using `cluster` name is recommended and takes precedence
                 q_options["cluster"] = s.cluster or q_options.get(

--- a/django_q/scheduler.py
+++ b/django_q/scheduler.py
@@ -82,7 +82,7 @@ def scheduler(broker: Broker = None):
                             break
 
                     s.next_run = next_run
-                    s.repeats += -1
+                    # s.repeats += -1 # Do not count the runs here, maybe use another variable for it
                 # send it to the cluster; any cluster name is allowed in multi-queue scenarios
                 # because `broker_name` is confusing, using `cluster` name is recommended and takes precedence
                 q_options["cluster"] = s.cluster or q_options.get(


### PR DESCRIPTION
Hello Folks,

The line of code s.repeats += -1 in the scheduler function has been commented out. This change is based on the understanding that s.repeats is incorrectly used as a counter for the number of executions of a task, which results in negative values once the task has been executed more times than initially scheduled.

Best Regards
Tobias