### PR TITLE
Fix repeating task after timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         - uses: actions/checkout@v3
         - name: Lint with ruff
           run: |
-            pipx install ruff==0.4.4
+            pipx install ruff==0.4.10
             ruff format . --check && ruff check .
 
   test:

--- a/django_q/exceptions.py
+++ b/django_q/exceptions.py
@@ -1,18 +1,19 @@
 import signal
-from typing import Optional
 
 class TimeoutException(SystemExit):
-    """Exception for when a worker takes too long to complete a task"""
+    """
+    Exception for when a worker takes too long to complete a task
+    Raising SystemExit will make sure the function terminates gracefully.
+    """
     pass
 
 
-class TimeoutHandler(Exception):
+class TimeoutHandler:
     def __init__(self, timeout: int):
         self._timeout = timeout
 
     def raise_timeout_exception(self, signum, frame):
-        raise TimeoutException('Task exceeded maximum timeout value '
-                              '({0} seconds)'.format(self._timeout))
+        raise TimeoutException(f"Task exceeded maximum timeout value ({self._timeout} seconds)")
 
     def __enter__(self):
         if self._timeout == -1:

--- a/django_q/exceptions.py
+++ b/django_q/exceptions.py
@@ -1,0 +1,28 @@
+import signal
+from typing import Optional
+
+class TimeoutException(SystemExit):
+    """Exception for when a worker takes too long to complete a task"""
+    pass
+
+
+class TimeoutHandler(Exception):
+    def __init__(self, timeout: Optional[int] = None):
+        self._timeout = timeout
+
+    def raise_timeout_exception(self, signum, frame):
+        raise TimeoutException('Task exceeded maximum timeout value '
+                              '({0} seconds)'.format(self._timeout))
+
+    def __enter__(self):
+        if self._timeout is None:
+            return
+        signal.signal(signal.SIGALRM, self.raise_timeout_exception)
+        signal.alarm(self._timeout)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._timeout is None:
+            return
+        """When getting out of the timeout, reset the alarm, so it won't trigger"""
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, signal.SIG_DFL)

--- a/django_q/exceptions.py
+++ b/django_q/exceptions.py
@@ -1,5 +1,3 @@
-import signal
-
 class TimeoutException(SystemExit):
     """
     Exception for when a worker takes too long to complete a task
@@ -8,22 +6,3 @@ class TimeoutException(SystemExit):
     pass
 
 
-class TimeoutHandler:
-    def __init__(self, timeout: int):
-        self._timeout = timeout
-
-    def raise_timeout_exception(self, signum, frame):
-        raise TimeoutException(f"Task exceeded maximum timeout value ({self._timeout} seconds)")
-
-    def __enter__(self):
-        if self._timeout == -1:
-            return
-        signal.signal(signal.SIGALRM, self.raise_timeout_exception)
-        signal.alarm(self._timeout)
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        if self._timeout == -1:
-            return
-        """When getting out of the timeout, reset the alarm, so it won't trigger"""
-        signal.alarm(0)
-        signal.signal(signal.SIGALRM, signal.SIG_DFL)

--- a/django_q/exceptions.py
+++ b/django_q/exceptions.py
@@ -7,7 +7,7 @@ class TimeoutException(SystemExit):
 
 
 class TimeoutHandler(Exception):
-    def __init__(self, timeout: Optional[int] = None):
+    def __init__(self, timeout: int):
         self._timeout = timeout
 
     def raise_timeout_exception(self, signum, frame):
@@ -15,13 +15,13 @@ class TimeoutHandler(Exception):
                               '({0} seconds)'.format(self._timeout))
 
     def __enter__(self):
-        if self._timeout is None:
+        if self._timeout == -1:
             return
         signal.signal(signal.SIGALRM, self.raise_timeout_exception)
         signal.alarm(self._timeout)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if self._timeout is None:
+        if self._timeout == -1:
             return
         """When getting out of the timeout, reset the alarm, so it won't trigger"""
         signal.alarm(0)

--- a/django_q/exceptions.py
+++ b/django_q/exceptions.py
@@ -3,6 +3,5 @@ class TimeoutException(SystemExit):
     Exception for when a worker takes too long to complete a task
     Raising SystemExit will make sure the function terminates gracefully.
     """
+
     pass
-
-

--- a/django_q/monitor.py
+++ b/django_q/monitor.py
@@ -117,25 +117,19 @@ def save_task(task, broker: Broker):
 
         # check if this task has previous results
         try:
-            existing_task = Task.objects.get(id=task["id"], name=task["name"])
+            task_obj = Task.objects.get(id=task["id"], name=task["name"])
             # only update the result if it hasn't succeeded yet
-            if not existing_task.success:
-                existing_task.stopped = task["stopped"]
-                existing_task.result = task["result"]
-                existing_task.success = task["success"]
-                existing_task.attempt_count = existing_task.attempt_count + 1
-                existing_task.save()
-
-            if (
-                Conf.MAX_ATTEMPTS > 0
-                and existing_task.attempt_count >= Conf.MAX_ATTEMPTS
-            ):
-                broker.acknowledge(task["ack_id"])
+            if not task_obj.success:
+                task_obj.stopped = task["stopped"]
+                task_obj.result = task["result"]
+                task_obj.success = task["success"]
+                task_obj.attempt_count = task_obj.attempt_count + 1
+                task_obj.save()
 
         except Task.DoesNotExist:
             # convert func to string
             func = get_func_repr(task["func"])
-            Task.objects.create(
+            task_obj = Task.objects.create(
                 id=task["id"],
                 name=task["name"],
                 func=func,
@@ -150,6 +144,13 @@ def save_task(task, broker: Broker):
                 success=task["success"],
                 attempt_count=1,
             )
+
+        if (
+            Conf.MAX_ATTEMPTS > 0
+            and task_obj.attempt_count >= Conf.MAX_ATTEMPTS
+        ):
+            broker.acknowledge(task["ack_id"])
+
     except Exception:
         logger.exception("Could not save task result")
 

--- a/django_q/monitor.py
+++ b/django_q/monitor.py
@@ -150,8 +150,6 @@ def save_task(task, broker: Broker):
                 success=task["success"],
                 attempt_count=1,
             )
-
-
     except Exception:
         logger.exception("Could not save task result")
 

--- a/django_q/timeout.py
+++ b/django_q/timeout.py
@@ -1,7 +1,10 @@
-from .exceptions import TimeoutException
 import signal
+
 from django.utils.translation import gettext_lazy as _
+
 from django_q.conf import logger
+
+from .exceptions import TimeoutException
 
 
 class TimeoutHandler:
@@ -9,7 +12,9 @@ class TimeoutHandler:
         self._timeout = timeout
 
     def raise_timeout_exception(self, signum, frame):
-        raise TimeoutException(f"Task exceeded maximum timeout value ({self._timeout} seconds)")
+        raise TimeoutException(
+            f"Task exceeded maximum timeout value ({self._timeout} seconds)"
+        )
 
     def __enter__(self):
         # if the timeout is -1, then there is no timeout and the task will always keep running until it's done or manually killed
@@ -18,9 +23,7 @@ class TimeoutHandler:
         try:
             signal.signal(signal.SIGALRM, self.raise_timeout_exception)
         except ValueError:  # ValueError is raised for Windows users
-            logger.debug(
-                _("SIGALARM is not available on your platform")
-            )
+            logger.debug(_("SIGALARM is not available on your platform"))
 
         signal.alarm(self._timeout)
 
@@ -32,6 +35,4 @@ class TimeoutHandler:
             signal.alarm(0)
             signal.signal(signal.SIGALRM, signal.SIG_DFL)
         except ValueError:  # ValueError is raised for Windows users
-            logger.debug(
-                _("SIGALARM is not available on your platform")
-            )
+            logger.debug(_("SIGALARM is not available on your platform"))

--- a/django_q/timeout.py
+++ b/django_q/timeout.py
@@ -1,0 +1,37 @@
+from .exceptions import TimeoutException
+import signal
+from django.utils.translation import gettext_lazy as _
+from django_q.conf import logger
+
+
+class TimeoutHandler:
+    def __init__(self, timeout: int):
+        self._timeout = timeout
+
+    def raise_timeout_exception(self, signum, frame):
+        raise TimeoutException(f"Task exceeded maximum timeout value ({self._timeout} seconds)")
+
+    def __enter__(self):
+        # if the timeout is -1, then there is no timeout and the task will always keep running until it's done or manually killed
+        if self._timeout == -1:
+            return
+        try:
+            signal.signal(signal.SIGALRM, self.raise_timeout_exception)
+        except ValueError:  # ValueError is raised for Windows users
+            logger.debug(
+                _("SIGALARM is not available on your platform")
+            )
+
+        signal.alarm(self._timeout)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._timeout == -1:
+            return
+        """When getting out of the timeout, reset the alarm, so it won't trigger"""
+        try:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, signal.SIG_DFL)
+        except ValueError:  # ValueError is raised for Windows users
+            logger.debug(
+                _("SIGALARM is not available on your platform")
+            )

--- a/django_q/worker.py
+++ b/django_q/worker.py
@@ -17,10 +17,10 @@ except core.exceptions.AppRegistryNotReady:
     django.setup()
 
 from django_q.conf import Conf, error_reporter, logger, resource, setproctitle
-from django_q.signals import post_spawn, pre_execute
-from django_q.utils import close_old_django_connections, get_func_repr
 from django_q.exceptions import TimeoutException
+from django_q.signals import post_spawn, pre_execute
 from django_q.timeout import TimeoutHandler
+from django_q.utils import close_old_django_connections, get_func_repr
 
 try:
     import psutil
@@ -90,7 +90,7 @@ def worker(
         # signal execution
         pre_execute.send(sender="django_q", func=f, task=task)
         # execute the payload
-        timer.value = timer_value # Busy
+        timer.value = timer_value  # Busy
         if timer.value != -1:
             timer.value += 3  # Add buffer so that guard doesn't kill the process on timeout before it gets processed
 

--- a/django_q/worker.py
+++ b/django_q/worker.py
@@ -19,7 +19,8 @@ except core.exceptions.AppRegistryNotReady:
 from django_q.conf import Conf, error_reporter, logger, resource, setproctitle
 from django_q.signals import post_spawn, pre_execute
 from django_q.utils import close_old_django_connections, get_func_repr
-from django_q.exceptions import TimeoutException, TimeoutHandler
+from django_q.exceptions import TimeoutException
+from django_q.timeout import TimeoutHandler
 
 try:
     import psutil

--- a/django_q/worker.py
+++ b/django_q/worker.py
@@ -89,7 +89,9 @@ def worker(
         # signal execution
         pre_execute.send(sender="django_q", func=f, task=task)
         # execute the payload
-        timer.value = timer_value + 3  # Busy. Add buffer so that guard doesn't kill the process before it gets processed
+        timer.value = timer_value # Busy
+        if timer.value != -1:
+            timer.value += 3  # Add buffer so that guard doesn't kill the process on timeout before it gets processed
 
         try:
             if f is None:
@@ -115,7 +117,6 @@ def worker(
                 error_reporter.report()
             if task.get("sync", False):
                 raise
-
         with timer.get_lock():
             # Process result
             task["result"] = result[0]

--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -79,6 +79,8 @@ timeout
 The number of seconds a worker is allowed to spend on a task before it's terminated. Defaults to ``None``, meaning it will never time out.
 Set this to something that makes sense for your project. Can be overridden for individual tasks.
 
+Note: for systems that don't have `SIGALRM` available (e.g. Windows), it will not raise an error properly. It will kill the task, but it will keep retrying until it finishes within the given time.
+
 See :ref:`retry` for details how to set values for timeout and retry.
 
 .. _time_zone:


### PR DESCRIPTION
Timeouts that happened with brokers that need acknowledging could have jobs that would keep retrying. This was caused due to the process being killed without sending the job back to the `monitor` function that would mark the job as failed and would pull the task from the broker. This wasn't an issue with brokers that automatically remove the task from the broker when it gets pulled.

I have implemented a context manager that will keep track of the time in the worker itself (so not by the guard function). It will end the running task and return a timeout error. That gets caught and then it gets pushed to the monitor to process.
It will also set the timeout to 0, so the guard can clean the process up and reincarnate a process (so we get a clean state for the next task).