### PR TITLE
fix: adds explicit int type casts to avoid TypeError on python 3.12

### DIFF
--- a/django_q/brokers/orm.py
+++ b/django_q/brokers/orm.py
@@ -11,7 +11,7 @@ from django_q.models import OrmQ
 
 
 def _timeout():
-    return timezone.now() + timedelta(seconds=Conf.RETRY)
+    return timezone.now() + timedelta(seconds=int(Conf.RETRY))
 
 
 class ORM(Broker):

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -357,7 +357,7 @@ class Sentinel:
         count = 0
         if not self.timeout:
             self.timeout = 30
-        while self.status() == Conf.STOPPING and count < self.timeout * 10:
+        while self.status() == Conf.STOPPING and count < int(self.timeout) * 10:
             sleep(0.1)
             Stat(self).save()
             count += 1

--- a/django_q/monitor.py
+++ b/django_q/monitor.py
@@ -81,7 +81,7 @@ def save_task(task, broker: Broker):
     :type broker: brokers.Broker
     """
     # SAVE LIMIT < 0 : Don't save success
-    if not task.get("save", Conf.SAVE_LIMIT >= 0) and task["success"]:
+    if not task.get("save", int(Conf.SAVE_LIMIT) >= 0) and task["success"]:
         return
     # enqueues next in a chain
     if task.get("chain", None):

--- a/django_q/monitor.py
+++ b/django_q/monitor.py
@@ -145,7 +145,9 @@ def save_task(task, broker: Broker):
                 attempt_count=1,
             )
 
-        if Conf.MAX_ATTEMPTS > 0 and task_obj.attempt_count >= Conf.MAX_ATTEMPTS:
+        if int(Conf.MAX_ATTEMPTS) > 0 and task_obj.attempt_count >= int(
+            Conf.MAX_ATTEMPTS
+        ):
             broker.acknowledge(task["ack_id"])
 
     except Exception:

--- a/django_q/worker.py
+++ b/django_q/worker.py
@@ -5,9 +5,9 @@ from multiprocessing.process import current_process
 from multiprocessing.queues import Queue
 
 from django import core
-from django.apps.registry import apps
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+from django.apps.registry import apps
 
 try:
     apps.check_apps_ready()
@@ -88,7 +88,7 @@ def worker(
         # signal execution
         pre_execute.send(sender="django_q", func=f, task=task)
         # execute the payload
-        timer.value = timer_value  # Busy
+        timer.value = int(timer_value)  # Busy
 
         try:
             if f is None:


### PR DESCRIPTION
This PR aims to fix TypeError issues like the following on python 3.12:

```
Process Process-b4c3f87af9414249a152b20657234756:
Traceback (most recent call last):
  File ".../lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File ".../lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File ".../lib/python3.12/site-packages/django_q/cluster.py", line 158, in __init__
    self.start()
  File ".../lib/python3.12/site-packages/django_q/cluster.py", line 167, in start
    self.guard()
  File ".../lib/python3.12/site-packages/django_q/cluster.py", line 325, in guard
    self.stop()
  File ".../lib/python3.12/site-packages/django_q/cluster.py", line 360, in stop
    while self.status() == Conf.STOPPING and count < self.timeout * 10:
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'int' and 'str'
08:29:18 [Q] INFO Q Cluster saturn-solar-arizona-uniform has stopped.
```