### PR TITLE
fix:(schedule DB conn error) close stale broker connections only

### DIFF
--- a/django_q/brokers/orm.py
+++ b/django_q/brokers/orm.py
@@ -1,13 +1,12 @@
 from datetime import timedelta
 from time import sleep
 
-from django import db
-from django.db import transaction
+from django.db import transaction, connections
 from django.utils import timezone
 
 from django_q.brokers import Broker
 from django_q.conf import Conf, logger
-from django_q.models import OrmQ
+from django_q.models import OrmQ, Schedule
 
 
 def _timeout():
@@ -23,7 +22,8 @@ class ORM(Broker):
             # Make sure stale connections in the broker thread are explicitly
             #   closed before attempting DB access.
             # logger.debug("Broker thread calling close_old_connections")
-            db.close_old_connections()
+            connection = connections[Conf.ORM]
+            connection.close_if_unusable_or_obsolete()
         else:
             logger.debug("Broker in an atomic transaction")
         return OrmQ.objects.using(Conf.ORM)


### PR DESCRIPTION
Reason for closing connection is to prevent `async()` errors from unusable connections.
https://github.com/Koed00/django-q/issues/124

This causes a connection error when scheduling tasks in a multi db setup which happens in a transaction
```shell
Traceback (most recent call last):
  File "/opt/pysetup/.venv/lib/python3.11/site-packages/django/db/backends/base/base.py", line 308, in _cursor
    return self._prepare_cursor(self.create_cursor(name))
                                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.11/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.11/site-packages/django/db/backends/postgresql/base.py", line 330, in create_cursor
    cursor = self.connection.cursor()
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pysetup/.venv/lib/python3.11/site-packages/psycopg/connection.py", line 852, in cursor
    self._check_connection_ok()
  File "/opt/pysetup/.venv/lib/python3.11/site-packages/psycopg/connection.py", line 485, in _check_connection_ok
    raise e.OperationalError("the connection is closed")
psycopg.OperationalError: the connection is closed

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/pysetup/.venv/lib/python3.11/site-packages/django_q/scheduler.py", line 139, in scheduler
    s.save()
```