### PR TITLE
chore: Update CI for Django 4.2 Python 3.12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,9 +28,6 @@ jobs:
             django: "5.0" 
           - python-version: "3.9"
             django: "5.0" 
-          # django 4.2 does not support 3.12
-          - python-version: "3.12"
-            django: "4.2" 
 
     services:
       disque:


### PR DESCRIPTION
Removed Python 3.12 and Django 4.2 items from the matrix, as Django 4.2.8 now supports Python 3.12 (as per https://github.com/django/django/commit/9afeb6b9b6d4e025306c918e7e717288049cbdfd)