### PR TITLE
Call mark_process_dead on the dead worker if prometheus_client is installed

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -21,7 +21,7 @@ from django.utils.translation import gettext_lazy as _
 
 # Local
 from django_q.brokers import Broker, get_broker
-from django_q.conf import Conf, get_ppid, logger, psutil, setproctitle
+from django_q.conf import Conf, get_ppid, logger, psutil, setproctitle, prometheus_multiprocess
 from django_q.humanhash import humanize
 from django_q.monitor import monitor
 from django_q.pusher import pusher
@@ -223,6 +223,8 @@ class Sentinel:
                 % {"name": process.name}
             )
         else:
+            if prometheus_multiprocess:
+                prometheus_multiprocess.mark_process_dead(process.pid)
             self.pool.remove(process)
             self.spawn_worker()
             if process.timer.value == 0:

--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -38,6 +38,11 @@ try:
 except ModuleNotFoundError:
     setproctitle = None
 
+try:
+    from prometheus_client import multiprocess as prometheus_multiprocess
+except ModuleNotFoundError:
+    prometheus_multiprocess = None
+
 
 class Conf:
     """


### PR DESCRIPTION
According to [documentation](https://prometheus.github.io/client_python/multiprocess/) of Prometheus client (see "3. Gunicorn configuration"), if you are using multiprocessing, and your process exits (ends, dies etc.), you need to notify Prometheus about the fact.