### PR TITLE
Fix try-catch for Windows

### DIFF
--- a/django_q/timeout.py
+++ b/django_q/timeout.py
@@ -34,5 +34,8 @@ class TimeoutHandler:
         try:
             signal.alarm(0)
             signal.signal(signal.SIGALRM, signal.SIG_DFL)
-        except (ValueError, AttributeError):  # AttributeError is raised for Windows users
+        except (
+            ValueError,
+            AttributeError,
+        ):  # AttributeError is raised for Windows users
             logger.debug(_("SIGALARM is not available on your platform"))

--- a/django_q/timeout.py
+++ b/django_q/timeout.py
@@ -20,12 +20,12 @@ class TimeoutHandler:
         # if the timeout is -1, then there is no timeout and the task will always keep running until it's done or manually killed
         if self._timeout == -1:
             return
+
         try:
             signal.signal(signal.SIGALRM, self.raise_timeout_exception)
-        except AttributeError:  # AttributeError is raised for Windows users
+            signal.alarm(self._timeout)
+        except (ValueError, AttributeError):  # ValueError is raised for Windows users
             logger.debug(_("SIGALARM is not available on your platform"))
-
-        signal.alarm(self._timeout)
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self._timeout == -1:
@@ -34,5 +34,5 @@ class TimeoutHandler:
         try:
             signal.alarm(0)
             signal.signal(signal.SIGALRM, signal.SIG_DFL)
-        except AttributeError:  # AttributeError is raised for Windows users
+        except (ValueError, AttributeError):  # AttributeError is raised for Windows users
             logger.debug(_("SIGALARM is not available on your platform"))


### PR DESCRIPTION
Need both `ValueError` to catch `signal.signal` not available and `AttributeError` to catch `signal.SIGALRM` missing.

Fixes #227 introduced by #223