### PR TITLE
Fix scheduler E721 warning

### DIFF
--- a/django_q/scheduler.py
+++ b/django_q/scheduler.py
@@ -65,7 +65,7 @@ def scheduler(broker: Broker = None):
                 if s.args:
                     args = ast.literal_eval(s.args)
                     # single value won't eval to tuple, so:
-                    if type(args) != tuple:
+                    if type(args) is not tuple:
                         args = (args,)
                 q_options = kwargs.get("q_options", {})
                 if s.intended_date_kwarg:

--- a/django_q/timeout.py
+++ b/django_q/timeout.py
@@ -34,5 +34,8 @@ class TimeoutHandler:
         try:
             signal.alarm(0)
             signal.signal(signal.SIGALRM, signal.SIG_DFL)
-        except (ValueError, AttributeError):  # AttributeError is raised for Windows users
+        except (
+            ValueError,
+            AttributeError,
+        ):  # AttributeError is raised for Windows users
             logger.debug(_("SIGALARM is not available on your platform"))

--- a/django_q/timeout.py
+++ b/django_q/timeout.py
@@ -20,12 +20,12 @@ class TimeoutHandler:
         # if the timeout is -1, then there is no timeout and the task will always keep running until it's done or manually killed
         if self._timeout == -1:
             return
+
         try:
             signal.signal(signal.SIGALRM, self.raise_timeout_exception)
-        except AttributeError:  # AttributeError is raised for Windows users
+            signal.alarm(self._timeout)
+        except (ValueError, AttributeError):  # ValueError is raised for Windows users
             logger.debug(_("SIGALARM is not available on your platform"))
-
-        signal.alarm(self._timeout)
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self._timeout == -1:
@@ -34,5 +34,5 @@ class TimeoutHandler:
         try:
             signal.alarm(0)
             signal.signal(signal.SIGALRM, signal.SIG_DFL)
-        except AttributeError:  # AttributeError is raised for Windows users
+        except (ValueError, AttributeError):  # AttributeError is raised for Windows users
             logger.debug(_("SIGALARM is not available on your platform"))


### PR DESCRIPTION
Minor fix for Ruff complaint:

```plain
django_q\scheduler.py:68:24: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
   |
66 |                     args = ast.literal_eval(s.args)
67 |                     # single value won't eval to tuple, so:
68 |                     if type(args) != tuple:
   |                        ^^^^^^^^^^^^^^^^^^^ E721
69 |                         args = (args,)
70 |                 q_options = kwargs.get("q_options", {})
```