### PR TITLE
Fix type check for args in scheduler.py E721

### DIFF
--- a/django_q/scheduler.py
+++ b/django_q/scheduler.py
@@ -65,7 +65,7 @@ def scheduler(broker: Broker = None):
                 if s.args:
                     args = ast.literal_eval(s.args)
                     # single value won't eval to tuple, so:
-                    if type(args) != tuple:
+                    if type(args) is not tuple:
                         args = (args,)
                 q_options = kwargs.get("q_options", {})
                 if s.intended_date_kwarg:


### PR DESCRIPTION
Minor fix for Ruff complaint:

```plain
django_q\scheduler.py:68:24: E721 Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
   |
66 |                     args = ast.literal_eval(s.args)
67 |                     # single value won't eval to tuple, so:
68 |                     if type(args) != tuple:
   |                        ^^^^^^^^^^^^^^^^^^^ E721
69 |                         args = (args,)
70 |                 q_options = kwargs.get("q_options", {})
```