### PR TITLE
Don't run cron when created

### DIFF
--- a/django_q/models.py
+++ b/django_q/models.py
@@ -304,6 +304,12 @@ class Schedule(models.Model):
     def __str__(self):
         return self.func
 
+    def save(self, *args, **kwargs):
+        if self.pk is None and self.schedule_type == self.CRON:
+            self.next_run = self.calculate_next_run()
+
+        return super().save(*args, **kwargs)
+
     success.boolean = True
     success.short_description = _("success")
     last_run.allow_tags = True


### PR DESCRIPTION
fixes #235

To do:
- [ ] write tests

```
>>> from django_q.models import Schedule
>>> from django_q.tasks import schedule
>>> schedule('math.hypot', 3, 4, schedule_type=Schedule.CRON, cron = '0 22 * * 1-5')
<Schedule: math.hypot>
>>> Schedule.objects.last().next_run
datetime.datetime(2024, 10, 15, 22, 0, tzinfo=datetime.timezone.utc)
>>> from datetime import datetime
>>> datetime.now()
datetime.datetime(2024, 10, 15, 2, 37, 28, 435132)
>>> 
```