### PR TITLE
Decrease the MAX_RSS set in test_cluster::test_max_rss

### DIFF
--- a/django_q/tests/test_cluster.py
+++ b/django_q/tests/test_cluster.py
@@ -487,7 +487,7 @@ def test_max_rss(broker, monkeypatch):
     stop_event = Event()
     cluster_id = uuidlib.uuid4()
     # override settings
-    monkeypatch.setattr(Conf, "MAX_RSS", 40000)
+    monkeypatch.setattr(Conf, "MAX_RSS", 20000)
     monkeypatch.setattr(Conf, "WORKERS", 1)
     # set a timer to stop the Sentinel
     threading.Timer(3, stop_event.set).start()


### PR DESCRIPTION
Hello,

A long time ago, I opened https://github.com/Koed00/django-q/issues/649 against django-q, because when building django-q in Debian I was having unexplained failures on armhf architectures on `test_max_rss`. After some poking and reading I discovered that `armhf` architecture is very memory efficient and therefore with a 400k RSS, the expected recycling which had been designed for `amd64` architectures was not occurring.

This MR is a fix I implemented in Debian to ensure the test works consistently on all archs.

I think it'd be a nice addition.

Bests!