### PR TITLE
Drop Python 3.8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,17 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
         django: [ "4.2", "5.0", "5.1"]
         exclude:
-          # django 5.1 does not support 3.8 and 3.9
-          - python-version: "3.8"
-            django: "5.1"
+          # django 5.1 does not support 3.9
           - python-version: "3.9"
             django: "5.1"
-          # django 5.0 does not support 3.8 and 3.9
-          - python-version: "3.8"
-            django: "5.0" 
+          # django 5.0 does not support 3.9
           - python-version: "3.9"
             django: "5.0" 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
     'Operating System :: MacOS',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
@@ -49,7 +48,7 @@ include = ['CHANGELOG.md']
 
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4"
+python = ">=3.9,<4"
 django = ">=4.2, <6"
 django-picklefield = "^3.1"
 


### PR DESCRIPTION
Python 3.8 reached EOL in October 2024 https://discuss.python.org/t/python-3-8-is-now-officially-eol/66983 .