### PR TITLE
Fix install path for CHANGELOG.md

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,10 @@ classifiers = [
     'Topic :: System :: Distributed Computing',
     'Topic :: Software Development :: Libraries :: Python Modules',
 ]
-include = ['CHANGELOG.md']
+
+include = [
+ { path = "CHANGELOG.md", format = "sdist" },
+]
 
 [tool.poetry.plugins] # Optional super table
 


### PR DESCRIPTION
The file should not be installed directly in site-packages. Use the correct include syntax to include them into the source distribution package only.

This was noticed while packaging django-q2 for Gentoo. The automated QA checking noticed that the CHANGELOG.md file would be installed into the site-packages root directory, which is wrong.

See here for details from the Gentoo QA Team: https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages and here for how to use the install directive https://python-poetry.org/docs/pyproject/#include-and-exclude.

This will fix the issue.