### PR TITLE
Fix poetry version in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         - name: Install dependencies with Django ${{ matrix.django }}
           run: |
             python -m pip install --upgrade pip
-            pip install poetry
+            pip install poetry==1.8.5
             poetry add "django==${{ matrix.django }}" --python=${{ matrix.python-version }}
             poetry install -E testing
         - name: Run Tests


### PR DESCRIPTION
Poetry version 2.0.0 seems to be causing issues in our CI. https://github.com/django-q2/django-q2/actions/runs/12729066315/job/35480632093