### PR TITLE
Update tested versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,19 +26,29 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
-        django: [ "4.2", "5.0", "5.1"]
+        python-version:
+        - "3.9"
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        django:
+        - "4.2"
+        - "5.0"
+        - "5.1"
+        - "5.2"
         exclude:
-          # django 5.1 does not support 3.8 and 3.9
-          - python-version: "3.8"
-            django: "5.1"
+          # django 5.2 does not support 3.9
+          - python-version: "3.9"
+            django: "5.2"
+          # django 5.1 does not support 3.9
           - python-version: "3.9"
             django: "5.1"
-          # django 5.0 does not support 3.8 and 3.9
-          - python-version: "3.8"
-            django: "5.0" 
+          # django 5.0 does not support 3.9
           - python-version: "3.9"
-            django: "5.0" 
+            django: "5.0"
+          # django 4.2 does not support 3.13
+          - python-version: "3.13"
+            django: "4.2"
 
     services:
       disque:
@@ -74,7 +84,7 @@ jobs:
           run: |
             python -m pip install --upgrade pip
             pip install poetry==1.8.5
-            poetry add "django==${{ matrix.django }}" --python=${{ matrix.python-version }}
+            poetry add "django~=${{ matrix.django }}a1" --python=${{ matrix.python-version }}
             poetry install -E testing
         - name: Run Tests
           run: |

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,10 @@ Requirements
 -  `Django <https://www.djangoproject.com>`__ > = 4.2
 -  `Django-picklefield <https://github.com/gintas/django-picklefield>`__
 
-Tested with: Python 3.8, 3.9, 3.10, 3.11 and 3.12. Works with Django 4.2.X and 5.0.X
+Tested with:
+
+* Python 3.9 to 3.13.
+* Django 4.2 to 5.2.
 
 Brokers
 ~~~~~~~

--- a/django_q/admin.py
+++ b/django_q/admin.py
@@ -138,7 +138,7 @@ class ScheduleAdmin(admin.ModelAdmin):
                 url = reverse("admin:django_q_success_change", args=(obj.task_id,))
             else:
                 url = reverse("admin:django_q_failure_change", args=(obj.task_id,))
-            return format_html(f'<a href="{url}">[{obj.task_name}]</a>')
+            return format_html('<a href="{}">[{}]</a>', url, obj.task_name)
         return None
 
     get_last_run.allow_tags = True

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -296,7 +296,7 @@ class Schedule(models.Model):
                 url = reverse("admin:django_q_success_change", args=(task.id,))
             else:
                 url = reverse("admin:django_q_failure_change", args=(task.id,))
-            return format_html(f'<a href="{url}">[{task.name}]</a>')
+            return format_html(f'<a href="{}">[{}]</a>', url, task.name)
         return None
 
     def __str__(self):

--- a/django_q/models.py
+++ b/django_q/models.py
@@ -296,7 +296,7 @@ class Schedule(models.Model):
                 url = reverse("admin:django_q_success_change", args=(task.id,))
             else:
                 url = reverse("admin:django_q_failure_change", args=(task.id,))
-            return format_html(f'<a href="{}">[{}]</a>', url, task.name)
+            return format_html('<a href="{}">[{}]</a>', url, task.name)
         return None
 
     def __str__(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,11 @@ classifiers = [
     'Operating System :: MacOS',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Internet :: WWW/HTTP',
     'Topic :: System :: Distributed Computing',
     'Topic :: Software Development :: Libraries :: Python Modules',
@@ -52,7 +52,7 @@ include = [
 
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4"
+python = ">=3.9,<4"
 django = ">=4.2, <6"
 django-picklefield = "^3.1"
 


### PR DESCRIPTION
1. Drop support for Python 3.8 which is EOL.
2. Add support for Python 3.13.
3. Add support for Django 5.2, currently in beta and [expected April](https://docs.djangoproject.com/en/5.2/releases/5.2/).