### PR TITLE
Fix to work with redis-py > 5

### DIFF
--- a/django_q/tests/settings.py
+++ b/django_q/tests/settings.py
@@ -116,7 +116,7 @@ CACHES = {
         "LOCATION": f"redis://{REDIS_HOST}:6379/0",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "PARSER_CLASS": "redis.connection.HiredisParser",
+            "PARSER_CLASS": "redis.connection.DefaultParser",
         },
     }
 }


### PR DESCRIPTION
This is needed for the tests to work when using a recent version of redis-py