### PR TITLE
Don't close DB connection if async_task was called with `sync=True`

### DIFF
--- a/django_q/monitor.py
+++ b/django_q/monitor.py
@@ -93,7 +93,8 @@ def save_task(task, broker: Broker):
             broker=broker,
         )
     # SAVE LIMIT > 0: Prune database, SAVE_LIMIT 0: No pruning
-    close_old_django_connections()
+    if not task.get("sync", False):
+        close_old_django_connections()
 
     try:
         filters = {}

--- a/django_q/worker.py
+++ b/django_q/worker.py
@@ -85,7 +85,8 @@ def worker(
         if not callable(f):
             # locate() returns None if f cannot be loaded
             f = pydoc.locate(f)
-        close_old_django_connections()
+        if not task.get("sync", False):
+            close_old_django_connections()
         timer_value = task.pop("timeout", timeout)
         # signal execution
         pre_execute.send(sender="django_q", func=f, task=task)


### PR DESCRIPTION
Consider this use case:

* In `settings.py`, "sync" is set to `False`
* But there are some tasks that should optionally be run sync

If the call looks like this:

```python
@transaction.atomic
def jobs_and_more(should_run_sync):
    ...
    async_task(modify_db, sync=should_run_sync)
    ...

def modify_db():
    ...

# Sample scenario
if DEBUG:
    jobs_and_more(True)
else:
    jobs_and_more(False)
```

... Then one is in for a bad surprise because `modify_db` will inherit the outside database transaction, but `close_old_django_connections` in `utils.py` only considers the global setting's "sync" flag. The database connection will be closed, and `modify_db` throws an exception.

I added a fix so that a task's `sync` attribute is first checked before calling `close_old_django_connections`.

* If `async_task(..., sync=True)`, `Conf.SYNC: True`: DB connection not closed
* If `async_task(..., sync=True)`, `Conf.SYNC: False`: DB connection not closed
* If `async_task(..., sync=False)`, `Conf.SYNC: True`: DB connection not closed
* If `async_task(..., sync=False)`, `Conf.SYNC: False`: DB connection closed