### PR TITLE
AttributeError when start_event is None, and guard process faster stop

### DIFF
--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -79,6 +79,20 @@ class Cluster:
         # is blocked in sentinel.join(). It is also necessary to check for start_event
         # being set to None by the signal handler.
         while self.start_event and not self.start_event.is_set():
+            # While waiting for the sentinel to start, also check for sentinel premature
+            # death
+            if self.sentinel and not self.sentinel.is_alive():
+                logger.error(
+                    _(
+                        "Q Cluster %(name)s failed to start. Sentinel exited "
+                        "with exit code %(exitcode)s."
+                    )
+                    % {"name": self.name, "exitcode": self.sentinel.exitcode}
+                )
+                raise RuntimeError(
+                    f"Q Cluster {self.name} failed to start: sentinel exited "
+                    f"with code {self.sentinel.exitcode}"
+                )
             sleep(0.1)
         return self.pid
 

--- a/django_q/cluster.py
+++ b/django_q/cluster.py
@@ -81,7 +81,11 @@ class Cluster:
         while self.start_event and not self.start_event.is_set():
             # While waiting for the sentinel to start, also check for sentinel premature
             # death
-            if self.sentinel and not self.sentinel.is_alive():
+            if not self.sentinel.is_alive():
+                if self.sentinel.exitcode == 0:
+                    # the cluster was stopped via SIGTERM/SIGINT and sentinel early
+                    # termination was intentional -- exit quietly
+                    break
                 logger.error(
                     _(
                         "Q Cluster %(name)s failed to start. Sentinel exited "

--- a/django_q/tests/test_cluster.py
+++ b/django_q/tests/test_cluster.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import sys
 import threading
 import uuid as uuidlib
@@ -95,6 +96,56 @@ def test_cluster_initial(broker):
     assert c.sentinel.is_alive() is False
     assert c.has_stopped
     assert c.stop() is False
+    broker.delete_queue()
+
+
+@pytest.mark.django_db
+def test_cluster_early_stop(broker, monkeypatch):
+    """
+    Test stopping the cluster before the sentinel has set the cluster's start_event
+    """
+
+    sentinel_event = Event()
+    test_event = Event()
+
+    def fake_ping():
+        """
+        Fake broker ping() method
+
+        This is called in the sentinel process's start() method and overriding it allows
+        us to synchronize the sentinel process with the main process to provide a
+        deterministic ordering of operations for the test.
+        """
+        sentinel_event.set()  # let the main process know the sentinel is waiting
+        test_event.wait()  # wait for the main process to let the sentinel proceed
+
+    def raise_sigterm():
+        # wait for the sentinel to be blocked in fake_ping()
+        sentinel_event.wait()
+        # stop the cluster via SIGTERM
+        os.kill(os.getpid(), signal.SIGTERM)
+        # unblock the sentinel
+        test_event.set()
+
+    monkeypatch.setattr(broker, "ping", fake_ping)
+
+    broker.list_key = "initial_test:q"
+    broker.delete_queue()
+    c = Cluster(broker=broker)
+    assert c.sentinel is None
+    assert c.stat.status == Conf.STOPPED
+
+    # Use a timer to stop the cluster while it is still starting up. The timer function
+    # is guaranteed to run before c.start() returns, as start() must wait for the
+    # sentinel to set the cluster's start_event, and the sentinel will block on
+    # test_event before setting start_event.
+    threading.Timer(0.5, raise_sigterm).start()
+
+    c.start()
+    stat = c.stat
+    assert stat.status == Conf.STOPPED
+    assert c.sentinel.is_alive() is False
+    assert c.has_stopped
     broker.delete_queue()
 
 

--- a/django_q/tests/test_cluster.py
+++ b/django_q/tests/test_cluster.py
@@ -99,54 +99,75 @@ def test_cluster_initial(broker):
     broker.delete_queue()
 
 
-@pytest.mark.django_db
-def test_cluster_early_stop(broker, monkeypatch):
-    """
-    Test stopping the cluster before the sentinel has set the cluster's start_event
-    """
-
+class TestEarlyClusterStop:
     sentinel_event = Event()
     test_event = Event()
 
-    def fake_ping():
+    @staticmethod
+    def _fake_ping_for_test_cluster_early_stop():
         """
-        Fake broker ping() method
+        Fake broker ping() method for test_cluster_early_stop()
 
         This is called in the sentinel process's start() method and overriding it allows
         us to synchronize the sentinel process with the main process to provide a
         deterministic ordering of operations for the test.
+
+        This is implemented as a static method so the patched broker remains pickleable
+        for passing to the sentinel process, in case anyone ever runs the test on
+        platforms like MacOS that use spawn Process start method.
         """
-        sentinel_event.set()  # let the main process know the sentinel is waiting
-        test_event.wait()  # wait for the main process to let the sentinel proceed
+        # let the main process know the sentinel is waiting
+        TestEarlyClusterStop.sentinel_event.set()
+        # wait for the main process to let the sentinel proceed. The timeout prevents
+        # the test from hanging if the main process terminates unexpectedly before
+        # setting the event.
+        assert TestEarlyClusterStop.test_event.wait(10)
 
-    def raise_sigterm():
-        # wait for the sentinel to be blocked in fake_ping()
-        sentinel_event.wait()
-        # stop the cluster via SIGTERM
-        os.kill(os.getpid(), signal.SIGTERM)
-        # unblock the sentinel
-        test_event.set()
+    @pytest.mark.django_db
+    def test_cluster_early_stop(self, broker, monkeypatch):
+        """
+        Test stopping the cluster before the sentinel has set the cluster's start_event
+        """
 
-    monkeypatch.setattr(broker, "ping", fake_ping)
+        def raise_sigterm():
+            # wait for the sentinel to be blocked in fake_ping(). Periodically check
+            # that the sentinel is alive in case the sentinel dies unexpectedly before
+            # setting the sentinel_event -- prevents the test from hanging if sentinel
+            # dies unexpectedly.
+            while True:
+                if self.sentinel_event.wait(0.5):
+                    break
+                if not c.sentinel.is_alive():
+                    break
+            # stop the cluster via SIGTERM
+            os.kill(os.getpid(), signal.SIGTERM)
+            # unblock the sentinel
+            self.test_event.set()
 
-    broker.list_key = "initial_test:q"
-    broker.delete_queue()
-    c = Cluster(broker=broker)
-    assert c.sentinel is None
-    assert c.stat.status == Conf.STOPPED
+        monkeypatch.setattr(
+            broker,
+            "ping",
+            self._fake_ping_for_test_cluster_early_stop,
+        )
 
-    # Use a timer to stop the cluster while it is still starting up. The timer function
-    # is guaranteed to run before c.start() returns, as start() must wait for the
-    # sentinel to set the cluster's start_event, and the sentinel will block on
-    # test_event before setting start_event.
-    threading.Timer(0.5, raise_sigterm).start()
+        broker.list_key = "initial_test:q"
+        broker.delete_queue()
+        c = Cluster(broker=broker)
+        assert c.sentinel is None
+        assert c.stat.status == Conf.STOPPED
 
-    c.start()
-    stat = c.stat
-    assert stat.status == Conf.STOPPED
-    assert c.sentinel.is_alive() is False
-    assert c.has_stopped
-    broker.delete_queue()
+        # Use a timer to stop the cluster while it is still starting up. The timer function
+        # is guaranteed to run before c.start() returns, as start() must wait for the
+        # sentinel to set the cluster's start_event, and the sentinel will block on
+        # test_event before setting start_event.
+        threading.Timer(0.5, raise_sigterm).start()
+
+        c.start()
+        stat = c.stat
+        assert stat.status == Conf.STOPPED
+        assert c.sentinel.is_alive() is False
+        assert c.has_stopped
+        broker.delete_queue()
 
 
 @pytest.mark.django_db

--- a/django_q/tests/test_cluster.py
+++ b/django_q/tests/test_cluster.py
@@ -150,6 +150,45 @@ def test_cluster_early_stop(broker, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_cluster_stop_responsive(broker, monkeypatch):
+    """
+    Ensure that stopping the cluster is responsive and does not wait for a full
+    GUARD_CYCLE.
+    """
+    timeout_seconds = 5
+
+    def timeout(signal, frame):
+        assert 0, f"cluster did not stop after {timeout_seconds}s"
+
+    broker.list_key = "initial_test:q"
+    broker.delete_queue()
+    # set a long GUARD_CYCLE -- greater than timeout_seconds
+    monkeypatch.setattr(Conf, "GUARD_CYCLE", timeout_seconds * 2)
+    c = Cluster(broker=broker)
+    assert c.sentinel is None
+    assert c.stat.status == Conf.STOPPED
+    assert c.start() > 0
+    assert c.sentinel.is_alive() is True
+    assert c.is_running
+    assert c.is_stopping is False
+    assert c.is_starting is False
+    sleep(0.5)
+    stat = c.stat
+    assert stat.status == Conf.IDLE
+    prev_handler = signal.signal(signal.SIGALRM, timeout)
+    try:
+        signal.alarm(timeout_seconds)
+        assert c.stop() is True
+    finally:
+        signal.alarm(0)  # cancel the alarm
+        signal.signal(signal.SIGALRM, prev_handler)
+    assert c.sentinel.is_alive() is False
+    assert c.has_stopped
+    assert c.stop() is False
+    broker.delete_queue()
+
+
+@pytest.mark.django_db
 def test_sentinel():
     start_event = Event()
     stop_event = Event()


### PR DESCRIPTION
This commit has two related fixes that come into play when frequently shutting down and restarting the cluster.

If a SIGINT or SIGTERM signal is received while the main process is waiting for the sentinel process to set start_event, the signal handler sets start_event to None, and the loop that polls start_event will raise an unhandled AttributeError attempting to check start_event.is_set().

The second issue is that the guard process sleeps for the guard cycle interval in each iteration before checking the stop event, preventing the guard cycle from terminating until the sleep completes. The cluster can be made more responsive to a shutdown request by using the event's wait(cycle) method rather than time.sleep(cycle) so the process wakes immediately when the event is set.

The commit also fixes the case where the guard process sleeps for an extra cycle when the cycle counter happens to have been reset to zero on the loop iterations when the scheduler is called.

This fix helps in our environment where we are frequently stopping and starting the cluster and where we have increased the guard cycle setting to several seconds.

This PR replaces #292 