### PR TITLE
Add worker-process post-execute signal

### DIFF
--- a/django_q/signals.py
+++ b/django_q/signals.py
@@ -43,3 +43,6 @@ pre_execute = Signal()
 
 # args: task
 post_execute = Signal()
+
+# args: func, task
+post_execute_in_worker = Signal()

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -32,8 +32,14 @@ executed by a worker. This signal provides two arguments:
 
 After executing a task
 """"""""""""""""""""""
-The ``django_q.signals.post_execute`` signal is emitted after a task is
-executed by a worker and processed by the monitor. It included the ``task`` dictionary with the result.
+- The ``django_q.signals.post_execute_in_worker`` signal is emitted after a task
+  is executed by a worker and processed by the **worker**. It included the ``task``
+  dictionary with the result. Note that this signal is **emitted from, and handled
+  by, the worker process itself**, not the monitor, unlike the ``post_execute``
+  signal below.
+- The ``django_q.signals.post_execute`` signal is emitted after a task is
+  executed by a worker and processed by the **monitor**. It included the ``task``
+  dictionary with the result.
 
 
 Subscribing to a signal
@@ -55,6 +61,10 @@ signal::
 
     @receiver(post_execute)
     def my_post_execute_callback(sender, task, **kwargs):
+        print(f"Task {task['name']} was executed with result {task['result']}")
+    
+    @receiver(post_execute_in_worker)
+    def my_post_execute_in_worker_callback(sender, func, task, **kwargs):
         print(f"Task {task['name']} was executed with result {task['result']}")
 
     @receiver(post_spawn)


### PR DESCRIPTION
Adds `post_execute_in_worker`.
This is so post-execution code can be run in the worker's process so we have access to any local context from the `pre_execute` signal receivers, which also run in the worker process.

Open to naming changes. Even though it can't overlap with the original `post_execute` (except when sync==true), I wanted to make it clear that it's a functionally different signal.
I considered adding aliases to the other signals with `m_` and `w_` prefixes and calling this one `w_post_execute`.