### PR TITLE
async_iter: fix BadSignature after the default Django cache expires

### DIFF
--- a/django_q/tasks.py
+++ b/django_q/tasks.py
@@ -461,7 +461,9 @@ def async_iter(func, args_iter, **kwargs):
     # save the original arguments
     broker = options["broker"]
     broker.cache.set(
-        f"{broker.list_key}:{iter_group}:args", SignedPackage.dumps(args_iter), timeout=None
+        f"{broker.list_key}:{iter_group}:args",
+        SignedPackage.dumps(args_iter),
+        timeout=None,
     )
     for args in args_iter:
         if not isinstance(args, tuple):

--- a/django_q/tests/test_cached.py
+++ b/django_q/tests/test_cached.py
@@ -141,7 +141,7 @@ def test_iter_default_cache_timeout(broker, settings):
     cache timeout expires.
     """
     cache_settings = deepcopy(settings.CACHES)
-    cache_settings['default']['TIMEOUT'] = 1
+    cache_settings["default"]["TIMEOUT"] = 1
     settings.CACHES = cache_settings
     broker.purge_queue()
     broker.cache.clear()


### PR DESCRIPTION
Fixes https://github.com/django-q2/django-q2/issues/285

`BadSignature` is from a `None` value, which I suspect is because of an expired cache entry. Async iters are [always cached](https://github.com/django-q2/django-q2/blob/master/django_q/tasks.py#L460) and therefore stored with [an infinite ttl](https://github.com/django-q2/django-q2/blob/master/django_q/monitor.py#L164). But the related args cache entry is [stored with default Django ttl](https://github.com/django-q2/django-q2/blob/master/django_q/tasks.py#L463) and can expire if the async iter takes longer than the configured `CACHES` timeout (which is 300 seconds by default).

Sorry for `time.sleep` in the test. It looks lame, but I think it's ultimately the cleanest and most direct way to reproduce the issue with a test.