### PR TITLE
Fix: qmonitor crash when passing int values to term.center

### DIFF
--- a/django_q/monitor_terminal.py
+++ b/django_q/monitor_terminal.py
@@ -173,7 +173,7 @@ def monitor(run_once=False, broker=None):
             )
             print(
                 term.move(i, 3 * col_width)
-                + term.white_on_cyan(term.center(queue_size, width=col_width))
+                + term.white_on_cyan(term.center(str(queue_size), width=col_width))
             )
             print(
                 term.move(i, 4 * col_width)
@@ -182,7 +182,7 @@ def monitor(run_once=False, broker=None):
             print(
                 term.move(i, 5 * col_width)
                 + term.white_on_cyan(
-                    term.center(models.Success.objects.count(), width=col_width)
+                    term.center(str(models.Success.objects.count()), width=col_width)
                 )
             )
             print(
@@ -192,7 +192,7 @@ def monitor(run_once=False, broker=None):
             print(
                 term.move(i, 7 * col_width)
                 + term.white_on_cyan(
-                    term.center(models.Failure.objects.count(), width=col_width)
+                    term.center(str(models.Failure.objects.count()), width=col_width)
                 )
             )
             # for testing


### PR DESCRIPTION

**Summary:**
Fixes a crash in `qmonitor` caused by passing integer values to `term.center`, which expects strings.

**Issue:**
Fixes #318

**Details:**
Multiple integer values were passed directly to `term.center`, including:

* `queue_size`
* `models.Success.objects.count()`
* `models.Failure.objects.count()`

This leads to:

```
AttributeError: 'int' object has no attribute 'isascii'
```

because `term.center` internally expects string input.

**Fix:**
Convert all affected values to strings before passing:

```python
term.center(str(queue_size), ...)
term.center(str(models.Success.objects.count()), ...)
term.center(str(models.Failure.objects.count()), ...)
```

**Impact:**

* Prevents runtime crash in `qmonitor`
* No breaking changes
* Ensures consistent type handling

**Tested:**

* Verified `python manage.py qmonitor` runs without errors after fix
* Tested on Python 3.13
