### PR TITLE
Fix unbounded growth of Broker.set_stat cluster master list

### DIFF
--- a/django_q/brokers/__init__.py
+++ b/django_q/brokers/__init__.py
@@ -106,8 +106,13 @@ class Broker:
             return
         key_list = self.cache.get(Conf.Q_STAT, [])
         if key not in key_list:
+            # Prune stale entries whose per-stat value has expired, so the
+            # master list cannot grow without bound across cluster restarts.
+            key_list = [k for k in key_list if self.cache.get(k) is not None]
             key_list.append(key)
-        self.cache.set(Conf.Q_STAT, key_list)
+            # timeout=None: master list lifetime is managed by membership
+            # changes, not by TTL refresh on every heartbeat.
+            self.cache.set(Conf.Q_STAT, key_list, None)
         return self.cache.set(key, value, timeout)
 
     def get_stat(self, key: str):

--- a/django_q/tests/test_brokers.py
+++ b/django_q/tests/test_brokers.py
@@ -35,6 +35,57 @@ def test_broker(monkeypatch):
     assert broker.get_stats("test:*") is None
 
 
+def test_broker_set_stat_prunes_stale_master_list():
+    # regression: set_stat should prune stale master-list entries on register
+    broker = Broker()
+    a_key = f"{Conf.Q_STAT}:A"
+    b_key = f"{Conf.Q_STAT}:B"
+    broker.cache.delete(Conf.Q_STAT)
+
+    broker.set_stat(a_key, "state_a", 3)
+    assert a_key in broker.cache.get(Conf.Q_STAT)
+
+    # Drop A's per-stat value to simulate a dead cluster whose TTL expired,
+    # leaving the master-list entry as a stale reference.
+    broker.cache.delete(a_key)
+    assert broker.get_stat(a_key) is None
+    assert a_key in broker.cache.get(Conf.Q_STAT)
+
+    # Registering B should prune stale A from the master list.
+    broker.set_stat(b_key, "state_b", 3)
+    key_list = broker.cache.get(Conf.Q_STAT)
+    assert a_key not in key_list
+    assert b_key in key_list
+    assert broker.get_stat(b_key) == "state_b"
+
+
+def test_broker_set_stat_skips_master_list_write_on_repeat(monkeypatch):
+    # set_stat should only write the master list when membership changes
+    broker = Broker()
+    a_key = f"{Conf.Q_STAT}:A"
+    broker.cache.delete(Conf.Q_STAT)
+
+    writes = []
+    orig_set = broker.cache.set
+
+    def counting_set(key, value, timeout=None, **kw):
+        if key == Conf.Q_STAT:
+            writes.append(key)
+        return orig_set(key, value, timeout, **kw)
+
+    monkeypatch.setattr(broker.cache, "set", counting_set)
+
+    # First call adds a new entry, one master-list write expected
+    broker.set_stat(a_key, "state_a", 3)
+    assert len(writes) == 1
+
+    # Subsequent calls for the same key must not rewrite the master list
+    broker.set_stat(a_key, "state_a", 3)
+    broker.set_stat(a_key, "state_a", 3)
+    broker.set_stat(a_key, "state_a", 3)
+    assert len(writes) == 1
+
+
 def test_redis(monkeypatch):
     monkeypatch.setattr(Conf, "DJANGO_REDIS", None)
     broker = get_broker()


### PR DESCRIPTION
Fixes #321.

## Problem

`Broker.set_stat()` is append-only to the master list at `Conf.Q_STAT` — stale entries are never pruned during normal heartbeat traffic. The only cleanup path, `get_stats()`, is triggered only by `django_q.admin` monitor views and the `qmonitor` CLI. On deployments that don't regularly poll the monitoring UIs, the master list grows monotonically with every cluster restart. On `DatabaseCache`, where every `cache.set` amplifies into three Postgres queries shipping the full pickled value on the wire, this produces measurable egress (~5 GB/day observed in our case — full numbers in the issue).

The code has been byte-identical since commit `4f39062` in Aug 2015 and has never been touched by any PR. Most users don't notice because Redis / memcached / locmem make the write cost negligible.

## Fix

Two coupled changes to `set_stat`, both load-bearing:

**1. Prune stale entries on new cluster registration.** Uses the same `self.cache.get(k) is not None` liveness check that `get_stats()` already performs on the read path. Bounds the list to currently-live clusters.

**2. Only write the master list when membership changes, with `timeout=None`.** Previously, `cache.set(Conf.Q_STAT, ...)` ran on every heartbeat, writing the full pickled list and refreshing Django's `DEFAULT_TIMEOUT` (so the list was functionally immortal). The new code writes the master list only inside the `if key not in key_list` branch, and pins it with `timeout=None` so its lifetime is governed by membership rather than TTL refresh.

Each change alone is insufficient:
- Pruning alone leaves the multi-Hz unconditional rewrites in place, which is the bulk of the egress cost.
- Moving-the-write-inside-`if` alone keeps the append-only growth — and without the `timeout=None`, the list would now actually expire every 300s and trigger a ~0.5s blind window for `get_stats()` every cycle.

## Tests

Two new regression tests in `test_brokers.py`, each covering a distinct half of the fix:

1. `test_broker_set_stat_prunes_stale_master_list` — registers cluster A, simulates A's death by dropping its per-stat key, registers cluster B, asserts the master list contains only B. Also asserts B's per-stat was stored correctly (guards the `return` path).

2. `test_broker_set_stat_skips_master_list_write_on_repeat` — uses `monkeypatch` to wrap `broker.cache.set` with a counter; registers the same cluster four times; asserts the master list was written exactly once.

Both tests fail if either half of the fix is reverted:
- Without pruning: `test_broker_set_stat_prunes_stale_master_list` fails with `AssertionError: a_key not in key_list` (list still contains A).
- Without the move-inside-`if`: `test_broker_set_stat_skips_master_list_write_on_repeat` fails with `AssertionError: len(writes) == 1` (writes counter grows with each call).

The pre-existing `test_broker` still passes unchanged.

## Backwards compatibility

- Public API, signature, and return value of `set_stat` unchanged.
- `get_stats()` still reads the master list and returns the same shape.
- The cache-is-None early return still fires (pre-existing `test_broker` covers this).
- `get_stats()`'s existing cleanup loop already removes dead entries on read, so the invariant "master list may contain dead keys" was never promised. This PR moves the same cleanup into the write path so it runs regardless of whether the monitor UI is polling.

## Out of scope (explicit)

- **#300.** Same pattern in `monitor.py::save_cached()`. `monitor.py` is on the rewrite backlog per #139 so I'd rather not touch it here. Happy to revisit after this lands.
- **`get_stats()`'s list-mutation-during-iteration bug.** While reviewing this area I noticed that `get_stats()` at lines 135-140 iterates `key_list` while calling `key_list.remove(key)` inside the loop — the classic Python iteration-mutation gotcha. Concrete trace: with `key_list = ['A','B','C','D']` where only `D` is alive, the cleanup skips `B` entirely and leaves the list as `['B','D']` instead of `['D']`. So the monitor-UI cleanup path has always been leaving half the stale entries behind per call (converging only after several calls). Independent of this PR — happy to open a separate one-liner fix after this lands if you'd like.
- **`get_many()` optimization.** The prune does `len(key_list)` individual `cache.get()` calls. `get_many()` would be one round trip on backends that support it. Legitimate follow-up — kept out to keep the diff minimal and match `get_stats()`'s existing single-get loop style.

## Alternative shapes considered

- **Splitting into two commits in one PR** (prune + move-write-inside-`if`). I kept them together because neither half is independently correct: pruning alone doesn't stop the rewrite amplification, and moving-write-inside-`if` alone regresses the master-list TTL to an unbounded grow loop. Happy to split if you'd prefer.
- **Hard cap on list size as defense-in-depth.** Rejected — would mask future bugs rather than surface them.
- **Storing the list in a backend-native sorted set / pattern key.** That's effectively the direction `monitor.py` rewrite (#139) would go. Too big for this PR.

## Real-world impact

From the originating incident (numbers in the issue):
- Before: 122-entry master list, ~10 `django_cache_table` writes/sec, ≈ 5 GB/day.
- After: 1-entry list, 0 writes/sec from this path, ≈ 0 bytes/day.

Our full incident was dominated by an unrelated application bug, but this was a real secondary ~5 GB/day leak that would have grown indefinitely. We've also applied a local `Q_CLUSTER['cache']` setting to disable Django-Q's stat cache on our side as an immediate mitigation, but shipping the fix upstream means everyone using `DatabaseCache` + frequent restarts is protected without config changes.

Thank you for maintaining django-q2!
