### PR TITLE
permits django commands without SECRET_KEY set

### DIFF
--- a/django_q/conf.py
+++ b/django_q/conf.py
@@ -7,6 +7,7 @@ from multiprocessing import cpu_count
 from warnings import warn
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
 
 from django_q.queues import Queue
@@ -211,7 +212,12 @@ class Conf:
 
     # Use the secret key for package signing
     # Django itself should raise an error if it's not configured
-    SECRET_KEY = settings.SECRET_KEY
+    # but suppress the exception early to allow other parts of the app to still run.
+    # For example any "python manage.py ..." command still runs even if SECRET_KEY is not set.
+    try:
+        SECRET_KEY = settings.SECRET_KEY
+    except ImproperlyConfigured:
+        SECRET_KEY = None
 
     # The redis stats key
     Q_STAT = f"django_q:{PREFIX}:cluster"

--- a/django_q/management/commands/qcluster.py
+++ b/django_q/management/commands/qcluster.py
@@ -1,5 +1,6 @@
 import os
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils.translation import gettext as _
 
@@ -28,6 +29,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        # Ensure that the cluster starts only if the SECRET_KEY is set, as it is required for signing.
+        settings.SECRET_KEY
         # Set alternative cluster_name before creating the cluster (cluster_name is broker's queue_name, too)
         cluster_name = options.get("cluster_name")
         if cluster_name:


### PR DESCRIPTION
* silences ImproperlyConfigured in Conf, which in turn allows django commands to run without exceptions. Example 'python manage.py check'.

* defers the exception to be thrown at run time when the 'qcluster' command is invoked, exiting early.

* closes #279