### PR TITLE
Respect Conf.POLL in Redis broker dequeue timeout

### DIFF
--- a/django_q/brokers/redis_broker.py
+++ b/django_q/brokers/redis_broker.py
@@ -19,7 +19,7 @@ class Redis(Broker):
         return self.connection.rpush(self.list_key, task)
 
     def dequeue(self):
-        task = self.connection.blpop(self.list_key, 1)
+        task = self.connection.blpop(self.list_key, timeout=Conf.POLL)
         if task:
             return [(None, task[1])]
 

--- a/django_q/tests/test_brokers.py
+++ b/django_q/tests/test_brokers.py
@@ -101,6 +101,24 @@ def test_redis(monkeypatch):
         broker.ping()
 
 
+def test_redis_dequeue_uses_configured_poll_timeout(monkeypatch):
+    # regression: Redis.dequeue() used to hardcode a 1 second blpop timeout,
+    # ignoring the configurable Conf.POLL setting (Q_CLUSTER["poll"]).
+    from unittest.mock import MagicMock
+
+    from django_q.brokers.redis_broker import Redis as RedisBroker
+
+    monkeypatch.setattr(Conf, "POLL", 5)
+    broker = RedisBroker.__new__(RedisBroker)
+    broker.list_key = "django_q:test:q"
+    broker.connection = MagicMock()
+    broker.connection.blpop.return_value = None
+
+    broker.dequeue()
+
+    broker.connection.blpop.assert_called_once_with(broker.list_key, timeout=Conf.POLL)
+
+
 def test_custom(monkeypatch):
     monkeypatch.setattr(Conf, "BROKER_CLASS", "django_q.brokers.redis_broker.Redis")
     broker = get_broker()


### PR DESCRIPTION
## Summary

Fixes #290.

`Redis.dequeue()` in `django_q/brokers/redis_broker.py` hardcoded the `blpop` timeout to `1` second, so the documented `Q_CLUSTER["poll"]` setting (`Conf.POLL`) had no effect on the Redis broker, even though every other broker honors it. This change passes `Conf.POLL` through to `blpop` instead of the hardcoded value.

## Changes

- `django_q/brokers/redis_broker.py`: `dequeue()` now calls `self.connection.blpop(self.list_key, timeout=Conf.POLL)` instead of a hardcoded `1`.
- `django_q/tests/test_brokers.py`: added a regression test (`test_redis_dequeue_uses_configured_poll_timeout`) that mocks the Redis connection and asserts `blpop` is called with the configured `Conf.POLL` value. This test does not require a live Redis server.

## Test plan

- [x] Added regression test using a mocked connection (no live Redis/network required); confirmed it fails against the original hardcoded-timeout code and passes with the fix.
- [x] Ran `ruff format --check .` and `ruff check .` (pinned to `0.4.10` as used in CI) — both clean.
- [x] Ran the existing `django_q/tests/test_brokers.py` suite; pre-existing tests that require a live Redis/Mongo service were unaffected by this change (same pass/fail status as on `master`).

This PR was written primarily by Claude Code; I reviewed the change and ran the tests before submitting.