### PR TITLE
Add croniter as optional extra.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ build-backend = ["poetry.core.masonry.api"]
 testing = ["django-redis", "croniter", "hiredis", "psutil", "iron-mq", "boto3", "pymongo", "blessed", "redis", "setproctitle"]
 rollbar = ["django-q-rollbar"]
 sentry = ["django-q-sentry"]
+croniter = ["croniter"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Allows django-q2[croniter] to be specified in a dependant's pyproject.toml.

Required because dependant may not explicitly use croniter in code and so it can be (erroneously) flagged as unused.